### PR TITLE
reward_logic_skeleton_implementation

### DIFF
--- a/ico_template.py
+++ b/ico_template.py
@@ -17,6 +17,7 @@ from nex.token.mytoken import Token
 from nex.token.nep5 import NEP5Handler
 from nex.token.crowdsale import Crowdsale
 from nex.token.crowdfunding import crowdfunding_create, crowdfunding_get_members
+from nex.token.reward import reward_user, calculate_reward, level_up, level_of
 
 
 def Main(operation, args):
@@ -110,6 +111,25 @@ def Main(operation, args):
 
                 Notify("Member addresses:")
                 Notify(member_addresses)
+                return True
+
+            if operation == 'reward':
+                ## checkwitness
+                address = args[0]
+                
+                ## ...
+                
+                ## use reward_user with address with master wallet
+                Notify("reward pong")
+                return True
+
+            if operation == 'level':
+                address = args[0]
+                
+                ## ...
+                
+                ## use level_of with address
+                Notify("level pong")
                 return True
 
             return 'unknown operation'

--- a/nex/common/storage.py
+++ b/nex/common/storage.py
@@ -27,3 +27,7 @@ class StorageAPI():
     def get_crowdfunding_total_key(self, address):
         key = concat(address, "crowdfunding_total")
         return key
+
+    def get_level_of_key(self, address):
+        key = concat(address, "level")
+        return key

--- a/nex/token/reward.py
+++ b/nex/token/reward.py
@@ -1,0 +1,97 @@
+from nex.common.storage import StorageAPI
+from boa.code.builtins import concat
+from boa.blockchain.vm.Neo.Runtime import CheckWitness, Notify
+
+
+def reward_user(address):
+    """
+    """
+    
+    ## to be called from Main upon 'operation == "reward"' if called by master wallet
+    
+    ## make use of 'calculate_reward' below
+    
+    """
+    C# REFERENCE IMPLEMENTATION
+    
+                /// Reward user according to his or her user level
+            
+                byte[] owner = Storage.Get(Storage.CurrentContext, "owner");
+            
+                // if (Runtime.CheckWitness(owner)) // Enable this clause after CoZ contest
+                BigInteger amount = RewardFunction(LevelUp(account));
+
+                Transfer(owner, account, amount);
+
+                return amount;
+    """
+    
+    return True
+
+
+def calculate_reward(address):
+    """
+    """
+    
+    ## make use of 'level_of' below
+    
+    """
+    C# REFERENCE IMPLEMENTATION                 <====== WE DO IT BETTER THIS TIME, THOUGH
+    
+            /// Compute user reward depending on user level
+            
+            BigInteger basicReward = 100000000; 
+            // TODO test if I can just use 'factor' here
+            BigInteger bonusFactor = 1;
+
+            /// Quick level up for demonstration purpose before official launch
+            if (level > 1) bonusFactor = 2;
+            if (level > 3) bonusFactor = 5;
+            if (level > 9) bonusFactor = 20;
+
+            return bonusFactor * basicReward;
+    """
+    
+    return True
+    
+
+def level_up(address):
+    """
+    """
+    
+    ## make use of 'level_up' below
+    
+    """
+    C# REFERENCE IMPLEMENTATION
+    
+            BigInteger newLevel = LevelOf(account) + 1;
+            
+            Storage.Put(Storage.CurrentContext, Key("L", account), newLevel);
+            
+            return newLevel;
+    """
+    
+    return True
+    
+
+def level_of(address):
+    """
+    """
+    
+    ## to be called from Main upon 'operation == "level"' if called by master wallet
+    
+    """
+    C# REFERENCE IMPLEMENTATION
+    
+            BigInteger nLevel = 0;
+
+            byte[] level = Storage.Get(Storage.CurrentContext, Key("L", account));
+
+            if (level != null)
+                nLevel = level.AsBigInteger();
+
+            return nLevel;
+    """
+    
+    return True
+    


### PR DESCRIPTION
Created reward.py in the token folder. The 4 function there mirror the ones of the old imusify contract but have empty bodies. I copypasted the C# reference implementations there. Main imports those functions and has code paths for reward and level query. We're going to make the rewards more fancy this time, though. The level-key is also added to storage, as is done with the crowdfunding functions. This means the implementation of the reward logic will be done a tiny bit difference this time too in that regard.